### PR TITLE
Don't Hardcode "arch" and "mktemp" Path

### DIFF
--- a/migcom.tproj/mig.sh
+++ b/migcom.tproj/mig.sh
@@ -91,9 +91,15 @@ fi
 cppflags="-D__MACH30__"
 
 files=
-arch=`/usr/bin/arch`
+## DARLING
+# arch=`/usr/bin/arch`
+arch=`uname -m`
+## /DARLING
 
-WORKTMP=`/usr/bin/mktemp -d "${TMPDIR:-/tmp}/mig.XXXXXX"`
+## DARLING
+# WORKTMP=`/usr/bin/mktemp -d "${TMPDIR:-/tmp}/mig.XXXXXX"`
+WORKTMP=`mktemp -d "${TMPDIR:-/tmp}/mig.XXXXXX"`
+## /DARLING
 if [ $? -ne 0 ]; then
       echo "Failure creating temporary work directory: ${WORKTMP}"
       echo "Exiting..."


### PR DESCRIPTION
This change existed in the previous version as a Darling-specific change, however, it was not documented as one.